### PR TITLE
Ensure nonempty lyrics

### DIFF
--- a/jukebox/Interacting_with_Jukebox.ipynb
+++ b/jukebox/Interacting_with_Jukebox.ipynb
@@ -285,7 +285,10 @@
         "                                       # progresses through lyrics (model also generates differently\n",
         "                                       # depending on if it thinks it's in the beginning, middle, or end of sample)\n",
         "hps.sample_length = (int(sample_length_in_seconds*hps.sr)//top_prior.raw_to_tokens)*top_prior.raw_to_tokens\n",
-        "assert hps.sample_length >= top_prior.n_ctx*top_prior.raw_to_tokens, f'Please choose a larger sampling rate'"
+        "assert hps.sample_length >= top_prior.n_ctx*top_prior.raw_to_tokens, f'Please choose a larger sampling rate'",
+        "def ensure_lyrics(meta):\n",
+        "  meta.update(dict(lyrics = meta[\"lyrics\"] or \" \"))\n",
+        "  return meta"
       ],
       "execution_count": 0,
       "outputs": []
@@ -381,6 +384,7 @@
         "\"\"\",\n",
         "            ),\n",
         "          ] * hps.n_samples\n",
+        "metas = [ensure_lyrics(meta) for meta in metas]\n",
         "labels = [None, None, top_prior.labeller.get_batch_labels(metas, 'cuda')]"
       ],
       "execution_count": 0,
@@ -705,7 +709,10 @@
         "                                       # progresses through lyrics (model also generates differently\n",
         "                                       # depending on if it thinks it's in the beginning, middle, or end of sample)\n",
         "hps.sample_length = (int(sample_length_in_seconds*hps.sr)//top_prior.raw_to_tokens)*top_prior.raw_to_tokens\n",
-        "assert hps.sample_length >= top_prior.n_ctx*top_prior.raw_to_tokens, f'Please choose a larger sampling rate'"
+        "assert hps.sample_length >= top_prior.n_ctx*top_prior.raw_to_tokens, f'Please choose a larger sampling rate'",
+        "def ensure_lyrics(meta):\n",
+        "  meta.update(dict(lyrics = meta[\"lyrics\"] or \" \"))\n",
+        "  return meta"
       ]
     },
     {
@@ -737,6 +744,7 @@
         "            \"\"\",\n",
         "            ),\n",
         "          ] * hps.n_samples\n",
+        "metas = [ensure_lyrics(meta) for meta in metas]\n",
         "labels = top_prior.labeller.get_batch_labels(metas, 'cuda')"
       ],
       "execution_count": 0,


### PR DESCRIPTION
In normal mode (not co-composing), setting the lyrics to empty can lead to errors about a variable "token" being used before it is defined. This can be circumvented by setting lyrics to a string containing a single space. In co-composing mode this somehow does not happen in my experience, but I fixed it there anyways so the two modes don't drift apart too much.